### PR TITLE
Get locations and parties from proper attribute types.

### DIFF
--- a/app/subtasks/resources.py
+++ b/app/subtasks/resources.py
@@ -39,8 +39,8 @@ def export_resources(self, org_slug, project_slug, api_key, bundle_url,
             for l in obj['links']:
                 links.setdefault(l['type'], []).append(l['id'])
 
-            obj['locations'] = ', '.join(links.get('locations', []))
-            obj['parties'] = ', '.join(links.get('parties', []))
+            obj['locations'] = ', '.join(links.get('spatialunit', []))
+            obj['parties'] = ', '.join(links.get('party', []))
             obj['tenurerelationship'] = ', '.join(
                 links.get('tenurerelationship', []))
             rows.append(obj)

--- a/tests/stubs/resources/resp1.json
+++ b/tests/stubs/resources/resp1.json
@@ -13,16 +13,16 @@
             "mime_type": "",
             "links": [
                 {
-                    "id": "abcd",
-                    "type": "project"
+                    "id": "1",
+                    "type": "spatialunit"
                 },
                 {
-                    "id": "export-tests",
-                    "type": "project"
+                    "id": "2",
+                    "type": "party"
                 },
                 {
-                    "id": "export-tests",
-                    "type": "project"
+                    "id": "3",
+                    "type": "tenurerelationship"
                 }
             ]
         },

--- a/tests/stubs/resources/resp2.json
+++ b/tests/stubs/resources/resp2.json
@@ -13,7 +13,7 @@
             "mime_type": "",
             "links": [
                 {
-                    "id": "abcd",
+                    "id": "4",
                     "type": "project"
                 }
             ]
@@ -28,12 +28,12 @@
             "mime_type": "",
             "links": [
                 {
-                    "id": "export-tests",
-                    "type": "project"
+                    "id": "5",
+                    "type": "spatialunit"
                 },
                 {
-                    "id": "export-tests",
-                    "type": "project"
+                    "id": "6",
+                    "type": "party"
                 }
             ]
         }

--- a/tests/test_subtasks_resources.py
+++ b/tests/test_subtasks_resources.py
@@ -50,10 +50,10 @@ class TestResources(unittest.TestCase):
             Sheet.append.call_args_list,
             [call(['id', 'name', 'description', 'original_file', 'filename',
                    'locations', 'parties', 'tenure relationship']),
-             call(['0', 'foo_0', None, 'foo', 'foo', '', '', '']),
+             call(['0', 'foo_0', None, 'foo', 'foo', '1', '2', '3']),
              call(['1', 'foo_1', None, 'foo', 'foo_2', '', '', '']),
              call(['3', 'foo_3', None, 'bar.tar.gz', 'bar.tar.gz', '', '', '']),
-             call(['4', 'foo_4', None, 'bar.tar.gz', 'bar_2.tar.gz', '', '', ''])])
+             call(['4', 'foo_4', None, 'bar.tar.gz', 'bar_2.tar.gz', '5', '6', ''])])
         Workbook.save.assert_called_once_with(
             'cadasta_export-tests_fakeId_/fake-tmp-dir/resources.xlsx')
         # Test S3


### PR DESCRIPTION
Getting empty `locations` and `parties` columns on resource export XLS.

![image](https://user-images.githubusercontent.com/897290/34614617-4ee936c6-f1ef-11e7-9b3a-56ff382446cc.png)
