### PR TITLE
 Add ID to relationship sheet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN useradd -M -d $PWD user
 RUN chown -R user.user $PWD
 
 # Setup App
+RUN apt-get update && apt-get install -y \
+    libgdal-dev  \
+    libgeos-dev
 COPY --chown=user:user requirements-test.txt ./
 RUN pip install --no-cache-dir -r requirements-test.txt
 COPY --chown=user:user requirements.txt ./

--- a/app/subtasks/xls.py
+++ b/app/subtasks/xls.py
@@ -87,6 +87,7 @@ def write_relationships_sheet(wb, base_url, api_key):
     url = '{base}/relationships/tenure/'.format(base=base_url)
 
     headers = [
+        'id',
         ('party_id', 'party'),
         ('spatial_unit_id', 'spatial_unit'),
         'tenure_type'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Fiona==1.7.11.post1
 openpyxl==2.5.1
 requests==2.18.4
 Shapely==1.6.4.post1
-git+https://github.com/celery/kombu@0f4da  # TODO: update to 4.1.1+ when released
+kombu==4.2.1

--- a/tests/test_subtasks_xls.py
+++ b/tests/test_subtasks_xls.py
@@ -134,10 +134,10 @@ class TestXlsExport(unittest.TestCase):
         self.assertEqual(
             workbook.create_sheet.return_value.append.call_args_list,
             [
-                call(['party_id', 'spatial_unit_id', 'tenure_type', 'asal_usul_lahan2', 'asal_usul_lahan3', 'asal_usul_lahan4']),
-                call(['mutrsbhsvyi89fy54r3spewq', '3t56e3me9e9krur5ftifsjdt', 'CU', 'sertifikat, bpn, stdb, sppl', 'sendiri, warisan, beli, beli_kebunjadi', 'more_ten']),
-                call(['kj3d2k9wkuz9sykn7f93ewzg', '3t56e3me9e9krur5ftifsjdt', 'GR', 'skt', 'sendiri', 'less_ten']),
-                call(['xkrtqij77c6c8qniqwukyex3', '3t56e3me9e9krur5ftifsjdt', 'WR', 'tanah_adat', 'beli_kebunjadi', 'less_ten']),
-                call(['duqwrmus556cxxetutpsxewz', '3t56e3me9e9krur5ftifsjdt', 'MR', 'sppl', 'lainnya2', 'less_ten'])
+                call(['id', 'party_id', 'spatial_unit_id', 'tenure_type', 'asal_usul_lahan2', 'asal_usul_lahan3', 'asal_usul_lahan4']),
+                call(['ry9569w5zzqwrgsbjg4k4qmb', 'mutrsbhsvyi89fy54r3spewq', '3t56e3me9e9krur5ftifsjdt', 'CU', 'sertifikat, bpn, stdb, sppl', 'sendiri, warisan, beli, beli_kebunjadi', 'more_ten']),
+                call(['eqdri7z5zw62ag9g3vcxs9p2', 'kj3d2k9wkuz9sykn7f93ewzg', '3t56e3me9e9krur5ftifsjdt', 'GR', 'skt', 'sendiri', 'less_ten']),
+                call(['5c2zv8scwhpfvniv6dwcgvnc', 'xkrtqij77c6c8qniqwukyex3', '3t56e3me9e9krur5ftifsjdt', 'WR', 'tanah_adat', 'beli_kebunjadi', 'less_ten']),
+                call(['b7uui6bprzy8b8uhrd8v249y', 'duqwrmus556cxxetutpsxewz', '3t56e3me9e9krur5ftifsjdt', 'MR', 'sppl', 'lainnya2', 'less_ten'])
             ]
         )


### PR DESCRIPTION
For the ZOA data migration, we need to relationship ID exported, so we can establish tenure-relationship resources in ArcGIS. 

### Changes

- Add reletionship ID to exports and adapt tests
- Fix docker file (the build was failing because it couldn't install shapely; not sure if the fix is the right way to go about it)
- Upgrade kombu requirement